### PR TITLE
Update fetch sources to match new naming structure of git sources.

### DIFF
--- a/centrally_managed_conda/fetch_sources.py
+++ b/centrally_managed_conda/fetch_sources.py
@@ -2,7 +2,7 @@
 
 import argparse
 import os.path
-from os.path import join, abspath, expanduser, isdir, isfile
+from os.path import join, abspath, expanduser, isdir, isfile, normpath
 import sys
 
 from conda_build import external
@@ -47,11 +47,17 @@ def git_source(meta, recipe_dir, GIT_CACHE):
     git_url = meta['git_url']
     if git_url.startswith('.'):
         # It's a relative path from the conda recipe
-        os.chdir(recipe_dir)
-        git_dn = abspath(expanduser(git_url))
-        git_dn = "_".join(git_dn.split(os.path.sep)[1:])
+        git_url = abspath(normpath(os.path.join(recipe_dir, git_url)))
+        if sys.platform == 'win32':
+            git_dn = git_url.replace(':', '_')
+        else:
+            git_dn = git_url[1:]
     else:
-        git_dn = git_url.split(':')[-1].replace('/', '_')
+        git_dn = git_url.split('://')[-1].replace('/', os.sep)
+        if git_dn.startswith(os.sep):
+            git_dn = git_dn[1:]
+        git_dn = git_dn.replace(':', '_')
+    
     cache_repo = cache_repo_arg = join(GIT_CACHE, git_dn)
 
     # update (or create) the cache repo

--- a/centrally_managed_conda/tests/unit/test_compose_recipes.py
+++ b/centrally_managed_conda/tests/unit/test_compose_recipes.py
@@ -66,10 +66,11 @@ class Test_cli(RecipeCreatingUnit):
         out = subprocess.check_output([sys.executable, '-m', 'centrally_managed_conda.compose_recipes',
                                      '--output-dir={}'.format(output),
                                      channel1, channel2])
-        self.assertEqual(out.strip().decode('utf-8'),
-                         '\n'.join(['Copying channel1/a',
-                                    'Copying channel1/b',
-                                    'Copying channel2/c']))
+
+        self.assertEqual(set(out.strip().decode('utf-8').splitlines()),
+                         set(['Copying channel1/a',
+                              'Copying channel1/b',
+                              'Copying channel2/c']))
         if out.strip():
             print(out.decode('utf-8'))
         # Check they are all there, except for a2.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
       description='Tools and documentation for deploying centrally managed conda environments.',
       author='Phil Elson',
       author_email='pelson.pub@gmail.com',
-      url='https://github.com/pelson/centrally-managed-conda',
+      url='https://github.com/SciTools-incubator/centrally-managed-conda',
       packages=['centrally_managed_conda'],
      )
 


### PR DESCRIPTION
It looks like `centrally-managed-conda.fetch_sources.git_source` was written to match the first half of the `conda_build.source.git_source` function in version 1.18.2 of conda-build

See current centrally-managed `git_source` function
https://github.com/lbdreyer/centrally-managed-conda/blob/master/centrally_managed_conda/fetch_sources.py#L40

See conda-build v1.18.2, `conda_build.source.git_source` function, lines 87 to 116
https://github.com/conda/conda-build/blob/1.18.2/conda_build/source.py#L87

I've updated it to match what conda_build now looks like but it's hardly a nice solution!
